### PR TITLE
PG Programmes include MBA and MCA

### DIFF
--- a/src/components/TopAppBar/TopAppBar.tsx
+++ b/src/components/TopAppBar/TopAppBar.tsx
@@ -101,7 +101,7 @@ function TopAppBar({ mode, toggleColorMode }: TopAppBarProps) {
         ],
         PG: [
           { title: "MBA", link: "#" },
-          { title: "MBA", link: "#" },
+          { title: "MCA", link: "#" },
         ],
       },
       Programs: [


### PR DESCRIPTION
In the PG programmes, there is a typographical error. AOT has 2 PG programmes namely, **MBA** and **MCA**.
But currently when hovered on the departments section, it shows **2 MBA** courses. 

Fix: Rename one "MBA" string to "MCA"

![typo_issue1](https://github.com/Team-ByteWise/aot-website/assets/138896045/99d0adf1-717a-4e2c-a221-ec26a3218a29)
